### PR TITLE
Support minimum ABI stable SPM. Swift 5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "GottaGoFast",
+        "repositoryURL": "https://github.com/broadwaylamb/GottaGoFast.git",
+        "state": {
+          "branch": null,
+          "revision": "098e92679419e509d42fd97d3e84292acd53e291",
+          "version": "0.2.0"
+        }
+      },
+      {
+        "package": "OpenCombine",
+        "repositoryURL": "https://github.com/broadwaylamb/OpenCombine.git",
+        "state": {
+          "branch": null,
+          "revision": "d57c878651aa86af581246e034c3d471c5e431c9",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+          "version": "2.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.0
 import PackageDescription
 
-let package = Package(
+var package = Package(
     name: "EnumKit",
     platforms: [
       .macOS(.v10_10), .iOS(.v10), .tvOS(.v10), .watchOS(.v4)
@@ -21,3 +21,13 @@ let package = Package(
             dependencies: ["EnumKit"]),
     ]
 )
+
+//#if !canImport(Combine)
+package.dependencies = [
+    .package(url: "https://github.com/broadwaylamb/OpenCombine.git", from: "0.3.0")
+]
+
+if let enumKit = package.targets.first(where: { $0.name == "EnumKit" }) {
+    enumKit.dependencies = [ "OpenCombine" ]
+}
+//#endif

--- a/Sources/EnumKit/Extensions/CapturePublisher.swift
+++ b/Sources/EnumKit/Extensions/CapturePublisher.swift
@@ -7,8 +7,10 @@
 
 #if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publishers {
     public struct Capture<Upstream, Output> : Publisher where Upstream : Publisher {
         public typealias Failure = Upstream.Failure
@@ -93,5 +95,3 @@ extension Publishers {
         }
     }
 }
-
-#endif

--- a/Sources/EnumKit/Extensions/Combine+CaseAccessible.swift
+++ b/Sources/EnumKit/Extensions/Combine+CaseAccessible.swift
@@ -7,8 +7,10 @@
 
 #if canImport(Combine)
 import Combine
+#else
+import OpenCombine
+#endif
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher where Output: CaseAccessible {
     
     /// Republishes all elements that match a provided case.
@@ -102,14 +104,12 @@ public extension Publisher where Output: CaseAccessible {
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher {
     func to<T>(type: T.Type) -> Publishers.ToType<Self, T> {
-        Publishers.ToType(upstream: self, type: type)
+        return Publishers.ToType(upstream: self, type: type)
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public extension Publisher where Output == CaseAccessible {
     
     /// Republishes all elements that match a provided case.
@@ -202,5 +202,3 @@ public extension Publisher where Output == CaseAccessible {
             return to(type: U.self).flatMap(case: pattern, maxPublishers: maxPublishers, transform)
     }
 }
-
-#endif

--- a/Tests/EnumKitTests/CombineCaptureTests.swift
+++ b/Tests/EnumKitTests/CombineCaptureTests.swift
@@ -8,13 +8,14 @@
 
 #if canImport(Combine)
 import Combine
+#else
+import OpenCombine
 #endif
 
 import XCTest
 import EnumKit
 
 class CombineCaptureTests: XCTestCase {
-    #if canImport(Combine)
     
     let events: [CaseAccessible] = [
         MockEnum.withAnonymousPayload("100"),
@@ -25,8 +26,6 @@ class CombineCaptureTests: XCTestCase {
     ]
     
     func testItCanCaptureAnonymousAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .capture(case: MockEnum.withAnonymousPayload)
@@ -45,8 +44,6 @@ class CombineCaptureTests: XCTestCase {
     }
     
     func testItCanCaptureNamedAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .capture(case: MockEnum.withNamedPayload)
@@ -64,8 +61,6 @@ class CombineCaptureTests: XCTestCase {
 
     
     func testItCanCaptureNoAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .capture(case: MockEnum.noAssociatedValue)
@@ -81,6 +76,4 @@ class CombineCaptureTests: XCTestCase {
         
         XCTAssertEqual(recording.events, expected)
     }
-        
-    #endif
 }

--- a/Tests/EnumKitTests/CombineExcludeTests.swift
+++ b/Tests/EnumKitTests/CombineExcludeTests.swift
@@ -7,13 +7,14 @@
 
 #if canImport(Combine)
 import Combine
+#else
+import OpenCombine
 #endif
 
 import XCTest
 import EnumKit
 
 class CombineExcludeTests: XCTestCase {
-    #if canImport(Combine)
     
     let events: [CaseAccessible] = [
         MockEnum.noAssociatedValue,
@@ -43,8 +44,6 @@ class CombineExcludeTests: XCTestCase {
     }
     
     func testItCanExcludeEventsWithAnonymousAssociatedValue() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .exclude(case: MockEnum.withAnonymousPayload)
@@ -65,8 +64,6 @@ class CombineExcludeTests: XCTestCase {
 
     
     func testItCanExcludeEventsWithNamedAssociatedValue() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .exclude(case: MockEnum.withNamedPayload)
@@ -84,6 +81,5 @@ class CombineExcludeTests: XCTestCase {
         
         XCTAssertEqual(recording.events, expected)
     }
-        
-    #endif
+
 }

--- a/Tests/EnumKitTests/CombineFilterTests.swift
+++ b/Tests/EnumKitTests/CombineFilterTests.swift
@@ -7,13 +7,14 @@
 
 #if canImport(Combine)
 import Combine
+#else
+import OpenCombine
 #endif
 
 import XCTest
 import EnumKit
 
 class CombineFilterTests: XCTestCase {
-    #if canImport(Combine)
     
     let events: [CaseAccessible] = [
         MockEnum.withAnonymousPayload("100"),
@@ -24,8 +25,6 @@ class CombineFilterTests: XCTestCase {
     ]
     
     func testItCanFilterAnonymousEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .filter(case: MockEnum.withAnonymousPayload)
@@ -44,8 +43,6 @@ class CombineFilterTests: XCTestCase {
     }
     
     func testItCanFilterNamedEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .filter(case: MockEnum.withNamedPayload)
@@ -62,8 +59,6 @@ class CombineFilterTests: XCTestCase {
     }
 
     func testItCanFilterNoAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .filter(case: MockEnum.noAssociatedValue)
@@ -78,6 +73,4 @@ class CombineFilterTests: XCTestCase {
         
         XCTAssertEqual(recording.events, expected)
     }
-        
-    #endif
 }

--- a/Tests/EnumKitTests/CombineMapTests.swift
+++ b/Tests/EnumKitTests/CombineMapTests.swift
@@ -8,13 +8,14 @@
 
 #if canImport(Combine)
 import Combine
+#else
+import OpenCombine
 #endif
 
 import XCTest
 import EnumKit
 
 class CombineMapTests: XCTestCase {
-    #if canImport(Combine)
     
     let events: [CaseAccessible] = [
         MockEnum.withAnonymousPayload("100"),
@@ -26,8 +27,6 @@ class CombineMapTests: XCTestCase {
     ]
     
     func testItCanMapAnonymousEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .map(case: MockEnum.withAnonymousPayload, Int.init)
@@ -47,8 +46,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanMapNamedEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .map(case: MockEnum.withNamedPayload, Int.init)
@@ -67,8 +64,6 @@ class CombineMapTests: XCTestCase {
 
     
     func testItCanMapNoAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .map(case: MockEnum.noAssociatedValue) { "Frank Sinatra" }
@@ -85,8 +80,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanCompactMapAnonymousEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .compactMap(case: MockEnum.withAnonymousPayload, Int.init)
@@ -105,8 +98,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanCompactMapNamedEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .compactMap(case: MockEnum.withNamedPayload, Int.init)
@@ -124,8 +115,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanCompactMapNoAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .compactMap(case: MockEnum.noAssociatedValue) { "Frank Sinatra" }
@@ -142,8 +131,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanFlatMapAnonymousEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .flatMap(case: MockEnum.withAnonymousPayload) { Just($0) }
@@ -163,8 +150,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanFlatMapNamedEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .flatMap(case: MockEnum.withNamedPayload) { Just($0) }
@@ -181,8 +166,6 @@ class CombineMapTests: XCTestCase {
     }
     
     func testItCanFlatMapNoAssociatedValueEvents() {
-        guard #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) else { return }
-
         let publisher = PassthroughSubject<CaseAccessible, Never>()
         let recording = publisher
             .flatMap(case: MockEnum.noAssociatedValue) { Just("Frank Sinatra") }
@@ -197,5 +180,5 @@ class CombineMapTests: XCTestCase {
         
         XCTAssertEqual(recording.events, expected)
     }
-    #endif
+    
 }


### PR DESCRIPTION
As of there's no specific feature of Swift 5.1 required in the project, is it good to make EnumKit Package.swift declares on lowest but ABI stable Swift version which is Swift 5.0