### PR TITLE
Fixed zero sized payloads and overloading enum cases issues

### DIFF
--- a/EnumKit.podspec
+++ b/EnumKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 
-    s.version = "1.1.0"
+    s.version = "1.1.1"
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.10'
     s.name = "EnumKit"
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
 	s.homepage = "https://www.pfrpg.net"
     s.author = { "Giuseppe Lanza" => "gringoire986@gmail.com" }
 
+    s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-weak_framework Combine' }
     s.source = {
         :git => "https://github.com/gringoireDM/EnumKit.git",
         :tag => s.version.to_s

--- a/EnumKit.xcodeproj/project.pbxproj
+++ b/EnumKit.xcodeproj/project.pbxproj
@@ -162,7 +162,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -175,7 +175,6 @@
 				OBJ_31 /* EnumKit.podspec */,
 				OBJ_32 /* enumKit.png */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -270,7 +269,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_25 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -379,9 +378,13 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-weak_framework",
+					Combine,
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = EnumKit;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -408,9 +411,13 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-weak_framework",
+					Combine,
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = EnumKit;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/Sources/EnumKit/Core/CaseAccessible.swift
+++ b/Sources/EnumKit/Core/CaseAccessible.swift
@@ -18,8 +18,9 @@ public extension CaseAccessible {
     
     /// Check if an enum case matches another case
     func matches(case: Self) -> Bool {
-        let targetStr = `case`.label
-        return label == targetStr
+        var root = self
+        var `case` = `case`
+        return memcmp(&root, &`case`, MemoryLayout<Self>.size) == 0
     }
     
     /// Check if an enum case matches a specific pattern
@@ -59,15 +60,14 @@ public extension CaseAccessible {
         
     /// Extract an associated value of the enum case if it is of the expected type
     func associatedValue<AssociatedValue>() -> AssociatedValue? {
-        return decompose()?.value
+        return decompose(expecting: AssociatedValue.self)?.value
     }
     
     /// Extract the associated value of the enum case if it matches a specific pattern
     func associatedValue<AssociatedValue>(matching pattern: (AssociatedValue) -> Self) -> AssociatedValue? {
-        guard let decomposed: (String, AssociatedValue) = decompose(),
-            let patternDecomposed: (String, AssociatedValue) = pattern(decomposed.1).decompose(),
+        guard let decomposed: ([String?], AssociatedValue) = decompose(expecting: AssociatedValue.self),
+            let patternDecomposed: ([String?], AssociatedValue) = pattern(decomposed.1).decompose(expecting: AssociatedValue.self),
             decomposed.0 == patternDecomposed.0 else { return nil }
-        
         return decomposed.1
     }
     
@@ -144,16 +144,23 @@ public extension CaseAccessible {
 }
 
 private extension CaseAccessible {
-    func decompose<AssociatedValue>() -> (label: String, value: AssociatedValue)? {
+    func decompose<AssociatedValue>(expecting: AssociatedValue.Type) -> (path: [String?], value: AssociatedValue)? {
         let mirror = Mirror(reflecting: self)
         assert(mirror.displayStyle == .enum, "These CaseAccessible default functions should be used exclusively for enums")
-        guard mirror.displayStyle == .enum,
-            let pair = Mirror(reflecting: self).children.first,
-            let label = pair.label,
-            let result = (pair.value as? AssociatedValue) ??
-                (Mirror(reflecting: pair.value).children.first?.value as? AssociatedValue) else {
-                    return nil
+        guard mirror.displayStyle == .enum else { return nil }
+        
+        var path: [String?] = []
+        var any: Any = self
+        
+        while case let (label?, anyChild)? = Mirror(reflecting: any).children.first {
+            path.append(label)
+            path.append(String(describing: type(of: anyChild)))
+            if let child = anyChild as? AssociatedValue { return (path, child) }
+            any = anyChild
         }
-        return (label, result)
+        if MemoryLayout<AssociatedValue>.size == 0 {
+            return (["\(self)"], unsafeBitCast((), to: AssociatedValue.self))
+        }
+        return nil
     }
 }

--- a/Tests/EnumKitTests/CaseAccessibleExtractionTests.swift
+++ b/Tests/EnumKitTests/CaseAccessibleExtractionTests.swift
@@ -24,6 +24,12 @@ class CaseAccessibleExtractionTests: XCTestCase {
         XCTAssertNil(enumCase.associatedValue())
     }
     
+    func testItCanExtractZeroSizedPayloads() {
+        let expected = ZeroSized()
+        let enumCase = MockEnum.zeroSized(expected)
+        XCTAssertEqual(enumCase.associatedValue(), expected)
+    }
+    
     func testItCanExtractPayloadThroughSubscript() {
         let expectedPayload = "David Bowie"
         let enumCase = MockEnum.withAnonymousPayload(expectedPayload)
@@ -38,5 +44,11 @@ class CaseAccessibleExtractionTests: XCTestCase {
     func testItCannotExtractPayloadThroughSubscript() {
         let enumCase = MockEnum.noAssociatedValue
         XCTAssertNil(enumCase[expecting: String.self])
+    }
+    
+    func testItCanExtractZeroSizedPayloadsThroughSubscript() {
+        let expected = ZeroSized()
+        let enumCase = MockEnum.zeroSized(expected)
+        XCTAssertEqual(enumCase[expecting: ZeroSized.self], expected)
     }
 }

--- a/Tests/EnumKitTests/CaseAccessibleMatchingTests.swift
+++ b/Tests/EnumKitTests/CaseAccessibleMatchingTests.swift
@@ -30,6 +30,36 @@ class CaseAccessibleMatchingTests: XCTestCase {
         XCTAssertFalse(enumCase.matches(case: MockEnum.withNamedPayload))
     }
     
+    func testItCanMatchOverloadingCases() {
+        let enumCase = MockEnum.overloading(24)
+        XCTAssertTrue(enumCase.matches(case: { MockEnum.overloading($0) }))
+    }
+    
+    func testItCanMatchNamedOverloadingCases() {
+        let enumCase = MockEnum.overloading(anInt: 24)
+        XCTAssertTrue(enumCase.matches(case: MockEnum.overloading(anInt:)))
+    }
+    
+    func testItCanFailMatchOverloadingCases() {
+        let enumCase = MockEnum.overloading(24)
+        XCTAssertFalse(enumCase.matches(case: MockEnum.overloading(anInt:)))
+    }
+    
+    func testItCanFailMatchNamedOverloadingCases() {
+        let enumCase = MockEnum.overloading(anInt: 24)
+        XCTAssertFalse(enumCase.matches(case: { MockEnum.overloading($0) }))
+    }
+    
+    func testItCanMatchNamedOverloadingCasesWithTuple() {
+        let enumCase = MockEnum.overloading(anInt: 24, andString: "aaa")
+        XCTAssertTrue(enumCase.matches(case: MockEnum.overloading(anInt:andString:)))
+    }
+    
+    func testItCanFailMatchNamedOverloadingCasesWithTuple() {
+        let enumCase = MockEnum.overloading(anInt: 24, andString: "aaa")
+        XCTAssertFalse(enumCase.matches(case: MockEnum.overloading(anInt:)))
+    }
+    
     func testItCanMatchNoPayloadCasesWithOperator() {
         let enumCase = MockEnum.noAssociatedValue
         XCTAssert(enumCase ~= MockEnum.noAssociatedValue)
@@ -69,5 +99,4 @@ class CaseAccessibleMatchingTests: XCTestCase {
         let enumCase = MockEnum.withAnonymousPayload("David Bowie")
         XCTAssertFalse(enumCase !~= MockEnum.withAnonymousPayload)
     }
-
 }

--- a/Tests/EnumKitTests/CaseAccessiblePatternExtractionTests.swift
+++ b/Tests/EnumKitTests/CaseAccessiblePatternExtractionTests.swift
@@ -31,6 +31,18 @@ class CaseAccessiblePatternExtractionTests: XCTestCase {
         XCTAssertEqual(enumCase[case: MockEnum.withAnonymousPayload], expectedPayload)
     }
     
+    func testItCanExtractZeroSizedPayloads() {
+        let expected = ZeroSized()
+        let enumCase = MockEnum.zeroSized(expected)
+        XCTAssertEqual(enumCase.associatedValue(matching: MockEnum.zeroSized), expected)
+    }
+    
+    func testItCanExtractZeroSizedPayloadsThroughSubscript() {
+        let expected = ZeroSized()
+        let enumCase = MockEnum.zeroSized(expected)
+        XCTAssertEqual(enumCase[case: MockEnum.zeroSized], expected)
+    }
+    
     func testSubscriptCanReturnDefault() {
         let enumCase = MockEnum.withAnonymousPayload("David Bowie")
         XCTAssertEqual(enumCase[case: MockEnum.anInt, default: 0], 0)

--- a/Tests/EnumKitTests/CaseAccessiblePatternExtractionTests.swift
+++ b/Tests/EnumKitTests/CaseAccessiblePatternExtractionTests.swift
@@ -43,6 +43,38 @@ class CaseAccessiblePatternExtractionTests: XCTestCase {
         XCTAssertEqual(enumCase[case: MockEnum.zeroSized], expected)
     }
     
+    func testItCanExtractPayloadOverloadingCases() {
+        let enumCase = MockEnum.overloading(24)
+        XCTAssertEqual(enumCase.associatedValue(matching: { MockEnum.overloading($0) }), 24)
+    }
+    
+    func testItCanExtractPayloadNamedOverloadingCases() {
+        let enumCase = MockEnum.overloading(anInt: 24)
+        XCTAssertEqual(enumCase.associatedValue(matching: MockEnum.overloading(anInt:)), 24)
+    }
+    
+    func testItCanFailExtractPayloadOverloadingCases() {
+        let enumCase = MockEnum.overloading(24)
+        XCTAssertNil(enumCase.associatedValue(matching: MockEnum.overloading(anInt:)))
+    }
+    
+    func testItCanFailExtractPayloadNamedOverloadingCases() {
+        let enumCase = MockEnum.overloading(anInt: 24)
+        XCTAssertNil(enumCase.associatedValue(matching: { MockEnum.overloading($0) }))
+    }
+    
+    func testItCanExtractNamedPayloadsOverloadingCasesWithTuple() {
+        let enumCase = MockEnum.overloading(anInt: 24, andString: "aaa")
+        let pair = enumCase.associatedValue(matching: MockEnum.overloading(anInt:andString:))
+        XCTAssertEqual(pair?.0, 24)
+        XCTAssertEqual(pair?.1, "aaa")
+    }
+    
+    func testItCanFailExtractNamedPayloadsOverloadingCasesWithTuple() {
+        let enumCase = MockEnum.overloading(anInt: 24, andString: "aaa")
+        XCTAssertNil(enumCase.associatedValue(matching: MockEnum.overloading(anInt:)))
+    }
+    
     func testSubscriptCanReturnDefault() {
         let enumCase = MockEnum.withAnonymousPayload("David Bowie")
         XCTAssertEqual(enumCase[case: MockEnum.anInt, default: 0], 0)

--- a/Tests/EnumKitTests/CaseAccessibleSequenceTests.swift
+++ b/Tests/EnumKitTests/CaseAccessibleSequenceTests.swift
@@ -11,13 +11,14 @@ import EnumKit
 class CaseAccessibleSequenceTests: XCTestCase {
     let enumCases = [
         MockEnum.noAssociatedValue,
-        MockEnum.anInt(10),
-        MockEnum.withNamedPayload(payload: "David"),
-        MockEnum.withAnonymousPayload("Freddy"),
-        MockEnum.withAnonymousPayload("Mercury"),
-        MockEnum.withNamedPayload(payload: "Bowie"),
-        MockEnum.anInt(20),
-        MockEnum.anInt(30)
+        .anInt(10),
+        .withNamedPayload(payload: "David"),
+        .withAnonymousPayload("Freddy"),
+        .withAnonymousPayload("Mercury"),
+        .withNamedPayload(payload: "Bowie"),
+        .anInt(20),
+        .anInt(30),
+        .zeroSized(ZeroSized())
     ]
 
     func testItCanExtractAssociatedValues() {
@@ -68,13 +69,14 @@ class CaseAccessibleSequenceTests: XCTestCase {
     func testItCanExcludeNoAssociatedValue() {
         let result = enumCases.exclude(case: MockEnum.noAssociatedValue)
         XCTAssertEqual(result, [
-            MockEnum.anInt(10),
-            MockEnum.withNamedPayload(payload: "David"),
-            MockEnum.withAnonymousPayload("Freddy"),
-            MockEnum.withAnonymousPayload("Mercury"),
-            MockEnum.withNamedPayload(payload: "Bowie"),
-            MockEnum.anInt(20),
-            MockEnum.anInt(30)
+            .anInt(10),
+            .withNamedPayload(payload: "David"),
+            .withAnonymousPayload("Freddy"),
+            .withAnonymousPayload("Mercury"),
+            .withNamedPayload(payload: "Bowie"),
+            .anInt(20),
+            .anInt(30),
+            .zeroSized(ZeroSized())
             ])
     }
     
@@ -86,12 +88,27 @@ class CaseAccessibleSequenceTests: XCTestCase {
     func testItCanExcludeAnonymousAssociatedValue() {
         let result = enumCases.exclude(case: MockEnum.withAnonymousPayload)
         XCTAssertEqual(result, [
-            MockEnum.noAssociatedValue,
-            MockEnum.anInt(10),
-            MockEnum.withNamedPayload(payload: "David"),
-            MockEnum.withNamedPayload(payload: "Bowie"),
-            MockEnum.anInt(20),
-            MockEnum.anInt(30)
+            .noAssociatedValue,
+            .anInt(10),
+            .withNamedPayload(payload: "David"),
+            .withNamedPayload(payload: "Bowie"),
+            .anInt(20),
+            .anInt(30),
+            .zeroSized(ZeroSized())
+            ])
+    }
+    
+    func testItCanExcludeZeroSizedAssociatedValue() {
+        let result = enumCases.exclude(case: MockEnum.zeroSized)
+        XCTAssertEqual(result, [
+            .noAssociatedValue,
+            .anInt(10),
+            .withNamedPayload(payload: "David"),
+            .withAnonymousPayload("Freddy"),
+            .withAnonymousPayload("Mercury"),
+            .withNamedPayload(payload: "Bowie"),
+            .anInt(20),
+            .anInt(30)
             ])
     }
     
@@ -103,12 +120,13 @@ class CaseAccessibleSequenceTests: XCTestCase {
     func testItCanExcludeNamedAssociatedValue() {
         let result = enumCases.exclude(case: MockEnum.withNamedPayload)
         XCTAssertEqual(result, [
-            MockEnum.noAssociatedValue,
-            MockEnum.anInt(10),
-            MockEnum.withAnonymousPayload("Freddy"),
-            MockEnum.withAnonymousPayload("Mercury"),
-            MockEnum.anInt(20),
-            MockEnum.anInt(30)
+            .noAssociatedValue,
+            .anInt(10),
+            .withAnonymousPayload("Freddy"),
+            .withAnonymousPayload("Mercury"),
+            .anInt(20),
+            .anInt(30),
+            .zeroSized(ZeroSized())
             ])
     }
     

--- a/Tests/EnumKitTests/Mocks/MockCaseAccessible.swift
+++ b/Tests/EnumKitTests/Mocks/MockCaseAccessible.swift
@@ -17,6 +17,10 @@ enum MockEnum: CaseAccessible, Equatable {
     case anotherInt(Int)
     case namedInt(integer: Int)
     case zeroSized(ZeroSized)
+    case overloading(Int)
+    case overloading(string: String)
+    case overloading(anInt: Int)
+    case overloading(anInt: Int, andString: String)
 }
 
 struct ZeroSized: Equatable {

--- a/Tests/EnumKitTests/Mocks/MockCaseAccessible.swift
+++ b/Tests/EnumKitTests/Mocks/MockCaseAccessible.swift
@@ -16,4 +16,9 @@ enum MockEnum: CaseAccessible, Equatable {
     case anInt(Int)
     case anotherInt(Int)
     case namedInt(integer: Int)
+    case zeroSized(ZeroSized)
+}
+
+struct ZeroSized: Equatable {
+    static func == (lhs: ZeroSized, rhs: ZeroSized) -> Bool { true }
 }


### PR DESCRIPTION
Fixes https://github.com/gringoireDM/EnumKit/issues/4
This PR also fixes overloading enum cases

```swift
enum Mock: CaseAccessible {
    case foo(Int)
    case foo(anInt: Int)
    case foo(anInt: Int, andAString: String)
}
```

is now possible to use.

`enumCase[case: { Mock.foo($0) }]`
`enumCase[case: Mock.foo(anInt:)]`
`enumCase[case: Mock.foo(anInt: andAString:)]`